### PR TITLE
Add process inspector

### DIFF
--- a/cmd/csi/command/inspect.go
+++ b/cmd/csi/command/inspect.go
@@ -9,5 +9,5 @@ import (
 var Inspect = cli.Command{
 	Name:        "inspect",
 	Usage:       "inspects and collects information about the system and specific characteristics",
-	Subcommands: []cli.Command{inspect.System},
+	Subcommands: []cli.Command{inspect.Process, inspect.System},
 }

--- a/cmd/csi/command/inspect/process.go
+++ b/cmd/csi/command/inspect/process.go
@@ -1,0 +1,40 @@
+package inspect
+
+import (
+	//	"encoding/json"
+	"fmt"
+	"github.com/codegangsta/cli"
+	"github.com/vosst/csi"
+	"gopkg.in/yaml.v2"
+	"os"
+	"strconv"
+)
+
+var (
+	processFlagPid = cli.StringFlag{"pid", "", "specify the pid of the process that should be inspected", ""}
+)
+
+func actionProcess(context *cli.Context) {
+	pid := os.Getpid()
+
+	if p := context.String(processFlagPid.Name); len(p) > 0 {
+		pid, _ = strconv.Atoi(p)
+	}
+
+	pi := csi.ProcessInspector{}
+	processInfo, _ := pi.Inspect(pid)
+
+	if b, err := yaml.Marshal(processInfo); err != nil {
+		fmt.Fprintf(context.App.Writer, "Failed to query process information")
+	} else {
+		fmt.Fprintf(context.App.Writer, "%s\n", b)
+	}
+}
+
+// Process collects process-specific information.
+var Process = cli.Command{
+	Name:   "process",
+	Usage:  "collects process-specific information",
+	Flags:  []cli.Flag{processFlagPid},
+	Action: actionProcess,
+}

--- a/proc/pid/auxv.go
+++ b/proc/pid/auxv.go
@@ -42,7 +42,6 @@ const (
 	AT_SECURE        = C.AT_SECURE        // Booleans, was exec setuid-like?
 	AT_BASE_PLATFORM = C.AT_BASE_PLATFORM // String identifying real platforms
 	AT_RANDOM        = C.AT_RANDOM        // Address of 16 random bytes
-	AT_HWCAP2        = C.AT_HWCAP2        // More machine-dependent hints about processor capabilities
 	AT_EXECFN        = C.AT_EXECFN        // Filename of executable
 	// Pointer to the global system page used for system calls and other nice things
 	AT_SYSINFO      = C.AT_SYSINFO

--- a/proc/pid/auxv.go
+++ b/proc/pid/auxv.go
@@ -1,0 +1,125 @@
+package pid
+
+// #include <elf.h>
+import "C"
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	AT_NULL          = C.AT_NULL          // End of vector
+	AT_IGNORE        = C.AT_IGNORE        // Entry should be ignored
+	AT_EXECFD        = C.AT_EXECFD        // File descriptor of program
+	AT_PHDR          = C.AT_PHDR          // Program headers for program
+	AT_PHENT         = C.AT_PHENT         // Size of program header entry
+	AT_PHNUM         = C.AT_PHNUM         // Number of program headers
+	AT_PAGESZ        = C.AT_PAGESZ        // System page size
+	AT_BASE          = C.AT_BASE          // Base address of interpreter
+	AT_FLAGS         = C.AT_FLAGS         // Flags
+	AT_ENTRY         = C.AT_ENTRY         // Entry point of program
+	AT_NOTELF        = C.AT_NOTELF        // Program is not elf
+	AT_UID           = C.AT_UID           // Real uid
+	AT_EUID          = C.AT_EUID          // Effective uid
+	AT_GID           = C.AT_GID           // Real gid
+	AT_EGID          = C.AT_EGID          // Effective gid
+	AT_CLKTCK        = C.AT_CLKTCK        // Frequency of times()
+	AT_PLATFORM      = C.AT_PLATFORM      // String identifying platform
+	AT_HWCAP         = C.AT_HWCAP         // Machine-dependent hints about processor capabilities
+	AT_FPUCW         = C.AT_FPUCW         // Used FPU control word
+	AT_DCACHEBSIZE   = C.AT_DCACHEBSIZE   // Data cache block size
+	AT_ICACHEBSIZE   = C.AT_ICACHEBSIZE   // Instruction cache block size
+	AT_UCACHEBSIZE   = C.AT_UCACHEBSIZE   // Unified cache block size
+	AT_IGNOREPPC     = C.AT_IGNOREPPC     // Entry should be ignored
+	AT_SECURE        = C.AT_SECURE        // Booleans, was exec setuid-like?
+	AT_BASE_PLATFORM = C.AT_BASE_PLATFORM // String identifying real platforms
+	AT_RANDOM        = C.AT_RANDOM        // Address of 16 random bytes
+	AT_HWCAP2        = C.AT_HWCAP2        // More machine-dependent hints about processor capabilities
+	AT_EXECFN        = C.AT_EXECFN        // Filename of executable
+	// Pointer to the global system page used for system calls and other nice things
+	AT_SYSINFO      = C.AT_SYSINFO
+	AT_SYSINFO_EHDR = C.AT_SYSINFO_EHDR
+	// Shapes of the caches, bits 0-3 contains associativity; bits 4-7 contains log2 of line size. Maks those to get cache size
+	AT_L1I_CACHESHAPE = C.AT_L1I_CACHESHAPE
+	AT_L1D_CACHESHAPE = C.AT_L1D_CACHESHAPE
+	AT_L2_CACHESHAPE  = C.AT_L2_CACHESHAPE
+	AT_L3_CACHESHAPE  = C.AT_L3_CACHESHAPE
+)
+
+func determineEndianess() binary.ByteOrder {
+	var x uint32 = 0x01020304
+
+	switch *(*byte)(unsafe.Pointer(&x)) {
+	case 0x01:
+		return binary.BigEndian
+	case 0x04:
+		return binary.LittleEndian
+	}
+
+	return nil
+}
+
+// Describes the contents of the ELF interpreter information passed to the process at exec time.
+type Auxv map[uint32]uint32
+
+// NewAuxv reads the /proc/pid/auxv entry and returns the correspoding Auxv instance if
+// reading the file was successful or an error otherwise.
+func NewAuxv(pid int) (Auxv, error) {
+	fn := filepath.Join(Dir(pid), "auxv")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	stat, err := f.Stat()
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to stat %s [%s]", fn, err))
+	}
+
+	b, err := syscall.Mmap(int(f.Fd()), 0, int(stat.Size()), syscall.PROT_READ, syscall.MAP_PRIVATE)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to mmap %s [%s]", fn, err))
+	}
+
+	defer syscall.Munmap(b)
+
+	return NewAuxvFromReader(bytes.NewReader(b)), nil
+}
+
+// NewAuxvFromReader reads the contents from reader returning
+// a corresponding Auxv instance or nil in case of issues.
+func NewAuxvFromReader(reader io.Reader) Auxv {
+	endianess := determineEndianess()
+
+	if endianess == nil {
+		return nil
+	}
+
+	auxv := Auxv(make(map[uint32]uint32))
+
+	pair := []uint32{0, 0}
+
+	for err := binary.Read(reader, endianess, &pair); err == nil; err = binary.Read(reader, endianess, &pair) {
+		if pair[0] == AT_NULL {
+			break
+		}
+
+		auxv[pair[0]] = pair[1]
+	}
+
+	return auxv
+}

--- a/proc/pid/cgroup.go
+++ b/proc/pid/cgroup.go
@@ -67,7 +67,7 @@ func NewCgroupFromReader(reader io.Reader) *Cgroup {
 	cg := Cgroup{}
 	br := bufio.NewReader(reader)
 
-	for line, err := br.ReadString('\n'); err == nil; line, err = br.ReadString('n') {
+	for line, err := br.ReadString('\n'); err == nil; line, err = br.ReadString('\n') {
 		if h, err := NewHierarchyFromLine(line); err == nil {
 			cg.Hierarchies = append(cg.Hierarchies, h)
 		}

--- a/proc/pid/cgroup.go
+++ b/proc/pid/cgroup.go
@@ -1,0 +1,77 @@
+package pid
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+type Hierarchy struct {
+	ID           int      // Hierarchy ID number
+	Subsystems   []string // Set of subsystems bound to the hierarchy
+	ControlGroup string   // Control group in the hierarchy to which the process belongs
+}
+
+func NewHierarchyFromLine(line string) (Hierarchy, error) {
+	h := Hierarchy{}
+	s := ""
+
+	if _, err := fmt.Sscanf(line, "%d:%s:%s", &h.ID, &s, &h.ControlGroup); err != nil {
+		return h, errors.New(fmt.Sprintf("Failed to parse line '%s' [%s]", line, err))
+	}
+
+	h.Subsystems = strings.Split(s, ",")
+	return h, nil
+}
+
+// Cgroup describes control group Hierarchies to which the process/task belongs.
+type Cgroup struct {
+	Hierarchies []Hierarchy
+}
+
+func NewCGroup(pid int) (*Cgroup, error) {
+	fn := filepath.Join(Dir(pid), "cgroup")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	stat, err := f.Stat()
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to stat %s [%s]", fn, err))
+	}
+
+	b, err := syscall.Mmap(int(f.Fd()), 0, int(stat.Size()), syscall.PROT_READ, syscall.MAP_PRIVATE)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to mmap %s [%s]", fn, err))
+	}
+
+	defer syscall.Munmap(b)
+
+	return NewCgroupFromReader(bytes.NewReader(b)), nil
+}
+
+func NewCgroupFromReader(reader io.Reader) *Cgroup {
+	cg := Cgroup{}
+	br := bufio.NewReader(reader)
+
+	for line, err := br.ReadString('\n'); err == nil; line, err = br.ReadString('n') {
+		if h, err := NewHierarchyFromLine(line); err == nil {
+			cg.Hierarchies = append(cg.Hierarchies, h)
+		}
+	}
+
+	return &cg
+}

--- a/proc/pid/cmdline.go
+++ b/proc/pid/cmdline.go
@@ -1,0 +1,41 @@
+package pid
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Cmdline describes the complete command line of a process, unless the process is a zombie.
+type Cmdline []string
+
+// NewCmdline reads the complete command line of the process identified by pid and returns
+// the original command line or an error in case of issues.
+func NewCmdline(pid int) (Cmdline, error) {
+	fn := filepath.Join(Dir(pid), "cmdline")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	return NewCmdlineFromReader(f), nil
+}
+
+// NewCmdlineFromReader parses all command line arguments from the given reader.
+func NewCmdlineFromReader(reader io.Reader) Cmdline {
+	br := bufio.NewReader(reader)
+	cmdline := Cmdline{}
+
+	for arg, err := br.ReadString('\x00'); err != nil; arg, err = br.ReadString('\x00') {
+		cmdline = append(cmdline, arg)
+	}
+
+	return cmdline
+}

--- a/proc/pid/cmdline.go
+++ b/proc/pid/cmdline.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Cmdline describes the complete command line of a process, unless the process is a zombie.
@@ -33,8 +34,8 @@ func NewCmdlineFromReader(reader io.Reader) Cmdline {
 	br := bufio.NewReader(reader)
 	cmdline := Cmdline{}
 
-	for arg, err := br.ReadString('\x00'); err != nil; arg, err = br.ReadString('\x00') {
-		cmdline = append(cmdline, arg)
+	for arg, err := br.ReadString('\x00'); err == nil; arg, err = br.ReadString('\x00') {
+		cmdline = append(cmdline, strings.TrimRight(arg, "\x00"))
 	}
 
 	return cmdline

--- a/proc/pid/cwd.go
+++ b/proc/pid/cwd.go
@@ -1,0 +1,24 @@
+package pid
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Cwd describes the current working directory of the process.
+type Cwd string
+
+// NewCwd determines the current working directory of the process identified by pid,
+// returning an error if following the link to the cwd fails.
+func NewCwd(pid int) (Cwd, error) {
+	fn := filepath.Join(Dir(pid), "cwd")
+
+	lr, err := os.Readlink(fn)
+	if err != nil {
+		return Cwd(lr), errors.New(fmt.Sprintf("Failed to resolve link %s to cwd [%s].", fn, err))
+	}
+
+	return Cwd(lr), nil
+}

--- a/proc/pid/environ.go
+++ b/proc/pid/environ.go
@@ -1,0 +1,59 @@
+package pid
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// Environ describes the environment of a process
+type Environ map[string]string
+
+// NewEnviron loads the environment for the process with the given pid.
+func NewEnviron(pid int) (Environ, error) {
+	fn := filepath.Join(Dir(pid), "environ")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	stat, err := f.Stat()
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to stat %s [%s]", fn, err))
+	}
+
+	b, err := syscall.Mmap(int(f.Fd()), 0, int(stat.Size()), syscall.PROT_READ, syscall.MAP_PRIVATE)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to mmap %s [%s]", fn, err))
+	}
+
+	defer syscall.Munmap(b)
+
+	return NewEnvironFromReader(bytes.NewReader(b)), nil
+}
+
+// NewEnvironFromReader reads the environment from reader.
+func NewEnvironFromReader(reader io.Reader) Environ {
+	br := bufio.NewReader(reader)
+
+	env := Environ{}
+
+	for arg, err := br.ReadString('\x00'); err != nil; arg, err = br.ReadString('\x00') {
+		kv := strings.Split(arg, ":")
+		env[kv[0]] = kv[1]
+	}
+
+	return env
+}

--- a/proc/pid/exe.go
+++ b/proc/pid/exe.go
@@ -1,0 +1,25 @@
+package pid
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Pathname of the executed command
+type Exe string
+
+// NewExe determines the path of the executed command from /proc/pid/exe.
+// Returns an error if following the symbolic link fails.
+func NewExe(pid int) (Exe, error) {
+	fn := filepath.Join(Dir(pid), "exe")
+
+	lr, err := os.Readlink(fn)
+	if err != nil {
+		return Exe(lr), errors.New(fmt.Sprintf("Failed to resolve link %s to cwd [%s].", fn, err))
+	}
+
+	return Exe(lr), nil
+
+}

--- a/proc/pid/fd.go
+++ b/proc/pid/fd.go
@@ -1,0 +1,75 @@
+package pid
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// File describes an fd referring to an actual file
+type File string
+
+// SocketOrPipe describes an fd refering to a socket or pipe
+type SocketOrPipe struct {
+	Type  string // The type, either socket or pipe
+	Inode uint   // The INode
+}
+
+// Anon describes an anonymous fd without an inode
+type Anon string
+
+// Fd is a slice of elements each representing an fd being in use by a process.
+//
+// Depending on the type of an individual fd, the element is either a File, a SocketOrPipe or
+// an Anon instance.
+type Fd []interface{}
+
+// NewFd returns all open fds for the process identified by pid.
+//
+// Returns an error if opening /proc/%{pid}/fd or a subsequent os.File.Readdir failed
+func NewFd(pid int) (Fd, error) {
+	fn := filepath.Join(Dir(pid), "fd")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to open %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	if entries, err := f.Readdir(0); err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	} else {
+		fd := Fd{}
+
+		for _, fi := range entries {
+			fni := filepath.Join(fn, fi.Name())
+			dest, _ := os.Readlink(fni)
+			// We could not stat the destination and assume that the fd is not
+			// an actual file but either a socket/pipe or an fd without an inode.
+			if _, err := os.Stat(dest); err != nil {
+				kv := strings.Split(dest, ":")
+
+				if len(kv) != 2 {
+					continue
+				}
+
+				// We got an fd without an inode, parsing the file type now.
+				if kv[0] == "anon_inode" {
+					fd = append(fd, Anon(strings.Trim(kv[1], "[]")))
+				} else {
+					inode := uint(0)
+					fmt.Sscanf(kv[1], "[%d]", &inode)
+					fd = append(fd, SocketOrPipe{kv[0], inode})
+				}
+			} else {
+				fd = append(fd, File(dest))
+			}
+		}
+
+		return fd, nil
+	}
+}

--- a/proc/pid/io.go
+++ b/proc/pid/io.go
@@ -1,0 +1,67 @@
+package pid
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// IO summarizes I/O statistics for a process
+type IO struct {
+	RChar               int // Characters read
+	WChar               int // Characters written
+	Syscr               int // Syscalls to read
+	Syscw               int // Syscalls to write
+	ReadBytes           int // Bytes read
+	WriteBytes          int // Bytes written
+	CancelledWriteBytes int // See man proc
+}
+
+// NewIO determines the io statistics for the process identified by pid.
+func NewIO(pid int) (*IO, error) {
+	fn := filepath.Join(Dir(pid), "io")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+	io := NewIOFromReader(f)
+	return io, nil
+}
+
+// NewIOFromReader reads I/O statistics from reader.
+func NewIOFromReader(reader io.Reader) *IO {
+	result := IO{}
+	br := bufio.NewReader(reader)
+
+	for line, err := br.ReadString('\n'); err == nil; line, err = br.ReadString('\n') {
+		if kv := strings.Split(line, ":"); len(kv) == 2 {
+			switch strings.TrimSpace(kv[0]) {
+			case "rchar":
+				result.RChar, _ = strconv.Atoi(strings.TrimSpace(kv[1]))
+			case "wchar":
+				result.WChar, _ = strconv.Atoi(strings.TrimSpace(kv[1]))
+			case "syscr":
+				result.Syscr, _ = strconv.Atoi(strings.TrimSpace(kv[1]))
+			case "syscw":
+				result.Syscw, _ = strconv.Atoi(strings.TrimSpace(kv[1]))
+			case "read_bytes":
+				result.ReadBytes, _ = strconv.Atoi(strings.TrimSpace(kv[1]))
+			case "write_bytes":
+				result.WriteBytes, _ = strconv.Atoi(strings.TrimSpace(kv[1]))
+			case "cancelled_write_bytes":
+				result.CancelledWriteBytes, _ = strconv.Atoi(strings.TrimSpace(kv[1]))
+			}
+		}
+	}
+
+	return &result
+}

--- a/proc/pid/limits.go
+++ b/proc/pid/limits.go
@@ -1,0 +1,173 @@
+package pid
+
+// #include <sys/resource.h>
+import "C"
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+)
+
+type ResourceLimit int
+
+const (
+	CpuTime        ResourceLimit = C.RLIMIT_CPU
+	FileSize                     = C.RLIMIT_FSIZE
+	DataSize                     = C.RLIMIT_DATA
+	StackSize                    = C.RLIMIT_STACK
+	CoreFileSize                 = C.RLIMIT_CORE
+	ResidentSize                 = C.RLIMIT_RSS
+	NoProcesses                  = C.RLIMIT_NPROC
+	OpenFiles                    = C.RLIMIT_NOFILE
+	LockedMemory                 = C.RLIMIT_MEMLOCK
+	AddressSpace                 = C.RLIMIT_AS
+	FileLocks                    = C.RLIMIT_LOCKS
+	PendingSignals               = C.RLIMIT_SIGPENDING
+	MsgQueueSize                 = C.RLIMIT_MSGQUEUE
+	NicePrio                     = C.RLIMIT_NICE
+	RealtimePrio                 = C.RLIMIT_RTTIME
+)
+
+func (self ResourceLimit) String() string {
+	switch self {
+	case CpuTime:
+		return "CpuTime"
+	case FileSize:
+		return "FileSize"
+	case DataSize:
+		return "DataSize"
+	case StackSize:
+		return "StackSize"
+	case CoreFileSize:
+		return "CoreFileSize"
+	case ResidentSize:
+		return "ResidentSize"
+	case NoProcesses:
+		return "NoProcesses"
+	case OpenFiles:
+		return "OpenFiles"
+	case LockedMemory:
+		return "LockedMemory"
+	case AddressSpace:
+		return "AddressSpace"
+	case FileLocks:
+		return "FileLocks"
+	case PendingSignals:
+		return "PendingSignals"
+	case MsgQueueSize:
+		return "MsgQueueSize"
+	case NicePrio:
+		return "NicePrio"
+	case RealtimePrio:
+		return "RealtimePrio"
+	}
+
+	return fmt.Sprintf("Unknown [%d]", self)
+}
+
+type Unit string
+
+const (
+	Bytes        Unit = "bytes"
+	Seconds           = "seconds"
+	Processes         = "processes"
+	Files             = "files"
+	Signals           = "signals"
+	Locks             = "locks"
+	Microseconds      = "us"
+	Unknown           = "unknown"
+
+	// Parses a single line from /proc/pid/limits
+	LineRegExp        = `([[:print:]]+?)\s\s+([[:digit:]]+|unlimited)\s\s+([[:digit:]]+|unlimited)\s\s+([[:alpha:]]+)`
+	SubmatchLimit     = 1
+	SubmatchSoftLimit = 2
+	SubmatchHardLimit = 3
+	SubmatchUnits     = 4
+)
+
+var (
+	keys = map[string]ResourceLimit{
+		"Max cpu time":          CpuTime,
+		"Max file size":         FileSize,
+		"Max data size":         DataSize,
+		"Max stack size":        StackSize,
+		"Max core file size":    CoreFileSize,
+		"Max resident size":     ResidentSize,
+		"Max processes":         NoProcesses,
+		"Max open files":        OpenFiles,
+		"Max locked memory":     LockedMemory,
+		"Max address space":     AddressSpace,
+		"Max file locks":        FileLocks,
+		"Max pending signals":   PendingSignals,
+		"Max msgqueue size":     MsgQueueSize,
+		"Max nice priority":     NicePrio,
+		"Max realtime priority": RealtimePrio,
+	}
+	lineRegExp = regexp.MustCompile(`([[:print:]]+?)\s\s+([[:digit:]]+|unlimited)\s\s+([[:digit:]]+|unlimited)\s\s+([[:alpha:]]+)?`)
+)
+
+// Limit describes a limit on a resource
+type Limit struct {
+	Soft *int // Soft limit, nil indicates unlimited
+	Hard *int // hard limit, nil indicates unlimited
+	Unit Unit // Unit of measurement
+}
+
+type Limits map[ResourceLimit]*Limit
+
+func NewLimits(pid int) (Limits, error) {
+	fn := filepath.Join(Dir(pid), "limits")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	return NewLimitsFromReader(f)
+}
+
+func NewLimitsFromReader(reader io.Reader) (Limits, error) {
+	limits := Limits{}
+	br := bufio.NewReader(reader)
+
+	for line, err := br.ReadString('\n'); err == nil; line, err = br.ReadString('\n') {
+		tokens := lineRegExp.FindStringSubmatch(line)
+		if len(tokens) < 4 {
+			// An error occured while parsing the line
+			continue
+		}
+
+		if v, present := keys[tokens[SubmatchLimit]]; present {
+			limit := Limit{nil, nil, Unknown}
+
+			if tokens[SubmatchSoftLimit] != "unlimited" {
+				if i, err := strconv.Atoi(tokens[SubmatchSoftLimit]); err == nil {
+					limit.Soft = &i
+				}
+			}
+
+			if tokens[SubmatchHardLimit] != "unlimited" {
+				if i, err := strconv.Atoi(tokens[SubmatchHardLimit]); err == nil {
+					limit.Hard = &i
+				}
+			}
+
+			if len(tokens) == 5 {
+				limit.Unit = Unit(tokens[SubmatchUnits])
+			}
+
+			limits[v] = &limit
+		}
+	}
+
+	return limits, nil
+}

--- a/proc/pid/maps.go
+++ b/proc/pid/maps.go
@@ -1,0 +1,111 @@
+package pid
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	mapsAddressBegin  = 2
+	mapsAddressEnd    = 3
+	mapsReadPerm      = 5
+	mapsWritePerm     = 6
+	mapsExecPerm      = 7
+	mapsPrivatePerm   = 8
+	mapsOffset        = 9
+	mapsDevMajor      = 11
+	mapsDevMinor      = 12
+	mapsInode         = 13
+	mapsPath          = 14
+	mapsSubmatchCount = 15
+)
+
+// mapsRegExp parses an individual line from /proc/%{pid}/maps. Please see
+// https://regex101.com/r/cD2tN2/1 for a more readable overview together with
+// an example. Index constants are easily verifiable over there, too.
+var mapsRegExp = regexp.MustCompile(`(([[:xdigit:]]+)\-([[:xdigit:]]+))\s+((\-|r)(\-|w)(\-|x)(\-|p))\s+([[:xdigit:]]+)\s+(([[:digit:]]+)\:([[:digit:]]+))\s+([[:digit:]]+)\s+(.+)`)
+
+// MemoryRegion describes a mapped memory region and its access permissions
+type MemoryRegion struct {
+	Address struct { // The addresses bounding the memory region
+		Begin int64 // Begin of the memory region
+		End   int64 // End of the memroy region
+	}
+
+	Permissions struct { // Access permissions on the memory region
+		Read    bool // Region can be read
+		Write   bool // Region can be written
+		Exec    bool // Region can be executed
+		Private bool // Region is private (copy on write)
+	}
+	Offset int64    // Offset into the file/device/whatever backing the memory region
+	Device struct { // Device backing the memory region
+		Major int // Major identifier
+		Minor int // Minor identifier
+	}
+	Inode int    // Inode on the device backing the memory region
+	Path  string // Usually the file backing the memory mapping
+}
+
+// Maps is the set of all mapped memory regions of a process
+type Maps []MemoryRegion
+
+// NewMaps reads the memory mappings from /proc/pid/maps, returning a Maps instance
+// and an error in case of issues.
+func NewMaps(pid int) (Maps, error) {
+	fn := filepath.Join(Dir(pid), "maps")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	return NewMapsFromReader(f)
+}
+
+// NewMapsFromReader parses memory mappings from reader.
+//
+// Returns all parsed memory mappings and an error. If the error
+// is nil, all memory mappings were successfully parsed.
+func NewMapsFromReader(reader io.Reader) (Maps, error) {
+	maps := Maps{}
+	br := bufio.NewReader(reader)
+
+	for line, err := br.ReadString('\n'); err == nil; line, err = br.ReadString('\n') {
+		tokens := mapsRegExp.FindStringSubmatch(strings.TrimRight(line, "\n"))
+
+		if len(tokens) >= mapsSubmatchCount {
+			mr := MemoryRegion{}
+
+			mr.Address.Begin, _ = strconv.ParseInt(tokens[mapsAddressBegin], 16, 64)
+			mr.Address.End, _ = strconv.ParseInt(tokens[mapsAddressEnd], 16, 64)
+
+			mr.Permissions.Read = tokens[mapsReadPerm] == "r"
+			mr.Permissions.Write = tokens[mapsWritePerm] == "w"
+			mr.Permissions.Exec = tokens[mapsExecPerm] == "x"
+			mr.Permissions.Private = tokens[mapsPrivatePerm] == "p"
+
+			mr.Offset, _ = strconv.ParseInt(tokens[mapsOffset], 16, 64)
+
+			mr.Device.Major, _ = strconv.Atoi(tokens[mapsDevMajor])
+			mr.Device.Minor, _ = strconv.Atoi(tokens[mapsDevMinor])
+
+			mr.Inode, _ = strconv.Atoi(tokens[mapsInode])
+			mr.Path = tokens[mapsPath]
+
+			maps = append(maps, mr)
+		}
+	}
+
+	return maps, nil
+}

--- a/proc/pid/oom_adj.go
+++ b/proc/pid/oom_adj.go
@@ -1,0 +1,55 @@
+package pid
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const (
+	OomAdjDefault    = 0   // Default adjustment value
+	OomAdjDisableOOM = -17 // Disables OOM killing for a process
+	OomAdjMin        = -16 // Minimum supported value
+	OomAdjMax        = 15  // Maximum supported value
+)
+
+// OomAdj describes the factor for adjusting the score used to select which
+// process should be killed in an out-of-memory (OOM) situation.
+type OomAdj int
+
+// NewOomAdj reads the OomAdj value for the process identified by pid
+//
+// Returns an error if /proc/%{pid}/oom_adj could not be opened for reading
+// or if the value read from the value exceeds the documented bounds.
+func NewOomAdj(pid int) (OomAdj, error) {
+	fn := filepath.Join(Dir(pid), "oom_adj")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return OomAdjDefault, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	return NewOomAdjFromReader(f)
+}
+
+// NewOomAdjFromReader reads the OomAdj value from the given stream
+//
+// Returns an error if the value exceeds the documented bounds.
+func NewOomAdjFromReader(reader io.Reader) (OomAdj, error) {
+	oomAdj := OomAdj(OomAdjDefault)
+
+	if _, err := fmt.Fscanf(reader, "%d", &oomAdj); err != nil {
+		return oomAdj, errors.New(fmt.Sprintf("Failed to parse OomAdj value [%s]", err))
+	}
+
+	if oomAdj < OomAdjDisableOOM || oomAdj > OomAdjMax {
+		return oomAdj, errors.New(fmt.Sprintf("Invalid OomAdj value %d", oomAdj))
+	}
+
+	return oomAdj, nil
+}

--- a/proc/pid/oom_score.go
+++ b/proc/pid/oom_score.go
@@ -1,0 +1,43 @@
+package pid
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// OomScore describes the current score that the kernel gives to this process for the
+// purpose of selecting a process for the OOM-killer.
+type OomScore int
+
+// NewOomScore reads the OomScore value for the process identified by pid
+//
+// Returns an error if /proc/%{pid}/oom_score could not be opened for reading
+func NewOomScore(pid int) (OomScore, error) {
+	fn := filepath.Join(Dir(pid), "oom_score")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return OomAdjDefault, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	return NewOomScoreFromReader(f)
+}
+
+// NewOomScoreFromReader reads the OomScore value from the given stream
+//
+// Returns an error if reading from the stream fails
+func NewOomScoreFromReader(reader io.Reader) (OomScore, error) {
+	oomScore := OomScore(0)
+
+	if _, err := fmt.Fscanf(reader, "%d", &oomScore); err != nil {
+		return oomScore, errors.New(fmt.Sprintf("Failed to parse OomScore value [%s]", err))
+	}
+
+	return oomScore, nil
+}

--- a/proc/pid/oom_score_adj.go
+++ b/proc/pid/oom_score_adj.go
@@ -1,0 +1,53 @@
+package pid
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// OomScoreAdj models the value used to adjust the badness heuristic
+type OomScoreAdj int
+
+const (
+	OomScoreAdjDefault = 0     // Default value
+	OomScoreAdjMin     = -1000 // Minimum supported value
+	OomScoreAdjMax     = 1000  // Maximum supported value
+)
+
+// NewOomScoreAdj reads the OomScoreAdj value for the process identified by pid
+//
+// Returns an error if /proc/%{pid}/oom_score_adj could not be opened for reading
+// or if the value read from the value exceeds the documented bounds.
+func NewOomScoreAdj(pid int) (OomScoreAdj, error) {
+	fn := filepath.Join(Dir(pid), "oom_score_adj")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return OomScoreAdjDefault, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	return NewOomScoreAdjFromReader(f)
+}
+
+// NewOomScoreAdjFromReader reads the OomScoreAdj value from the given reader
+//
+// Returns an error if the value exceeds the documented bounds.
+func NewOomScoreAdjFromReader(reader io.Reader) (OomScoreAdj, error) {
+	oomScoreAdj := OomScoreAdj(OomScoreAdjDefault)
+
+	if _, err := fmt.Fscanf(reader, "%d", &oomScoreAdj); err != nil {
+		return oomScoreAdj, errors.New(fmt.Sprintf("Failed to parse OomScoreAdj value [%s]", err))
+	}
+
+	if oomScoreAdj < OomScoreAdjMin || oomScoreAdj > OomScoreAdjMax {
+		return oomScoreAdj, errors.New(fmt.Sprintf("Invalid OomScoreAdj value %d", oomScoreAdj))
+	}
+
+	return oomScoreAdj, nil
+}

--- a/proc/pid/pid.go
+++ b/proc/pid/pid.go
@@ -1,0 +1,13 @@
+package pid
+
+import (
+	"fmt"
+	"github.com/vosst/csi/proc"
+	"path/filepath"
+)
+
+// Dir returns the subdirectory containing information about the process with id pid.
+func Dir(id int) string {
+	// TODO(tvoss): How to handle negative pid values?
+	return filepath.Join(proc.Dir, fmt.Sprint(id))
+}

--- a/proc/pid/root.go
+++ b/proc/pid/root.go
@@ -1,0 +1,25 @@
+package pid
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Root of the filesystem as seen by a process
+type Root string
+
+// NewRoot determines the filsystem root of the process identified by pid
+//
+// Returns an error if resolving the symbolic link fails, usually caused by
+// the process's main thread having exited already.
+func NewRoot(pid int) (Root, error) {
+	fn := filepath.Join(Dir(pid), "root")
+
+	if r, err := os.Readlink(fn); err != nil {
+		return "", errors.New(fmt.Sprintf("Failed to resolve symbolic link [%s]", err))
+	} else {
+		return Root(r), nil
+	}
+}

--- a/proc/pid/stat.go
+++ b/proc/pid/stat.go
@@ -1,0 +1,141 @@
+package pid
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+)
+
+// State describes the state of a process
+//
+// Known values are presented in constants, taken from ${KERNELSRC}/fs/proc/array.c
+type State string
+
+// String pretty prints a process State instance
+func (self State) String() string {
+	switch self {
+	case Running:
+		return "Running"
+	case Sleeping:
+		return "Sleeping"
+	case DiskSleep:
+		return "DiskSleep"
+	case Zombie:
+		return "Zombie"
+	case Stopped:
+		return "Stopped"
+	case TracingStop:
+		return "TracingStop"
+	case Dead:
+		return "Dead"
+	}
+
+	return "Unknown"
+}
+
+const (
+	Running     State = "R"
+	Sleeping          = "S"
+	DiskSleep         = "D"
+	Zombie            = "Z"
+	Stopped           = "T"
+	TracingStop       = "t"
+	Dead              = "X"
+)
+
+// Stat provides status information about the process as used by ps(1)
+type Stat struct {
+	Pid                 int    // The process id
+	Comm                string // Filename of the executable in parentheses
+	State               State  // State of the process
+	Ppid                int    // The PID of the parent process
+	Pgrp                int    // The process group ID of the process
+	Session             int    // The session ID of the process
+	TtyNr               int    // Controlling terminal of the process
+	Tpgid               int    // ID of the foreground process of the controlling tmerinal of the process
+	Flags               uint   // Kernel flags word of the process
+	Minflt              uint   // Number of minor faults the process has made which have not required loading a memory page from disk
+	Cminflt             uint   // Number of minor faults that the process's waited-for children have made
+	Majflt              uint   // Number of major faults that the process's waited-for children have made
+	Cmajflt             uint   // Number of major faults that process's waited-for children have made
+	Utime               uint   // Amount of time that this process has been scheduled in user mode, in clock ticks
+	Stime               uint   // Amount of time that this process has been scheduled in kernel mode, in clock ticks
+	Cutime              int    // Amount of time that this process's waited-for children have been scheduled in kernel mode, in clock ticks
+	Cstime              int    // Amount of time that this process's waited-for children have been scheduled in kernel mode, in clock ticks
+	Priority            int    // Raw nice value as represented in the kernel or negated scheduling priority, minus one, for processes running a real-time scheduling policy
+	Nice                int    // The nice value, in the range 19 (low priority) to -20 (high priority)
+	NumThreads          int    // Number of threads in this process
+	Itrealvalue         uint   // Time in jiffies before the next SIGALRM is sent to the process due to an interval timer
+	StartTime           uint   // Time the process started after system boot.
+	Vsize               uint   // Virtual memory size in bytes
+	Rss                 uint   // Resident set size, number of pages the process has in real memory
+	RssLim              uint   // Current soft limit in bytes on the rss of the process
+	StartCode           uint   // Address above which program text can run
+	EndCode             uint   // Address below which program text can run
+	StartStack          uint   // Address of the start (i.e. bottom) of the stack
+	Kstkesp             uint   // Current value of ESP (stack pointer), as found in the kernel stack page for the process
+	Kstkeip             uint   // The current EIP (instruction pointer)
+	Signal              uint   // The bitmap of pending signals, displayed as a decimal number.
+	Blocked             uint   // The bitmap of blocked signals, displayed as a decimal number.
+	SigIgnore           uint   // The bitmap of ignored signals, displayed as a decimal number.
+	SigCatch            uint   // The bitmap of caught signals, displayed as a decimal number.
+	Wchan               uint   // The channel in which the process is waiting, where channel is the address of a system call.
+	Nswap               uint   // Number of pages swapped.
+	Cnswap              uint   // Cumulative nswap for child processes
+	ExitSignal          int    // Signal to be sent to parent when we die
+	Processor           int    // CPU number last executed on
+	RtPriority          uint   // Real-time scheduling priority, in the range 1-99 for processes scheduled under a real-time policy, or 0, for non-real-time processes
+	Policy              uint   // Scheduling policy
+	DelayacctBlkioTicks uint   // Aggregated block I/O delays, measured in ticks
+	GuestTime           uint   // Guest time of the process (time spent running a virtual CPU for a gust OS), in clock ticks
+	CguestTime          int    // Guest time of the process's children, measured in clock ticks
+}
+
+// NewStat reads /proc/%{pid}/stat into a Stat instance.
+//
+// Returns an error if opening /proc/%{pid}/stat or parsing an individual value fails.
+func NewStat(pid int) (*Stat, error) {
+	fn := filepath.Join(Dir(pid), "stat")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	return NewStatFromReader(f)
+}
+
+// NewStatFromReader parses a Stat instance from the given reader.
+//
+// Returns an error if parsing an individual value fails.
+func NewStatFromReader(reader io.Reader) (*Stat, error) {
+	stat := Stat{}
+
+	// We rely on reflection to step through the individual elements
+	// of Stat and scan them from reader one by one. Fortunately, Fscan is
+	// clever enough to do the right thing for numerical integer values.
+	v := reflect.ValueOf(&stat).Elem()
+
+	// We need the type later on to provide a rich error message in case
+	// scanning an individual value fails.
+	t := reflect.TypeOf(stat)
+
+	// TODO(tvoss): Right now, we iterate over all fields in the struct, failing if any of those fails to be scanned
+	// We might want to consider member annotations in the future to handle
+	// optional values.
+	for i := 0; i < v.NumField(); i++ {
+		// We need a pointer to the field for passing it to Fscan.
+		field := v.Field(i).Addr()
+		if _, err := fmt.Fscan(reader, field.Interface()); err != nil {
+			return nil, errors.New(fmt.Sprintf("Failed to parse field %s [%v]", t.Field(i).Name, err))
+		}
+	}
+
+	return &stat, nil
+}

--- a/proc/pid/stat.go
+++ b/proc/pid/stat.go
@@ -9,6 +9,40 @@ import (
 	"reflect"
 )
 
+// Flags is a bitfield holding process flags.
+type Flags uint
+
+// Taken from ${KERNELSRC}/include/linux/sched.h
+const (
+	PF_EXITING        = 0x00000004 // getting shut down
+	PF_EXITPIDONE     = 0x00000008 // pi exit done on shut down
+	PF_VCPU           = 0x00000010 // I'm a virtual CPU
+	PF_WQ_WORKER      = 0x00000020 // I'm a workqueue worker
+	PF_FORKNOEXEC     = 0x00000040 // forked but didn't exec
+	PF_MCE_PROCESS    = 0x00000080 // process policy on mce errors
+	PF_SUPERPRIV      = 0x00000100 // used super-user privileges
+	PF_DUMPCORE       = 0x00000200 // dumped core
+	PF_SIGNALED       = 0x00000400 // killed by a signal
+	PF_MEMALLOC       = 0x00000800 // Allocating memory
+	PF_NPROC_EXCEEDED = 0x00001000 // set_user noticed that RLIMIT_NPROC was exceeded
+	PF_USED_MATH      = 0x00002000 // if unset the fpu must be initialized before use
+	PF_USED_ASYNC     = 0x00004000 // used async_schedule*(), used by module init
+	PF_NOFREEZE       = 0x00008000 // this thread should not be frozen
+	PF_FROZEN         = 0x00010000 // frozen for system suspend
+	PF_FSTRANS        = 0x00020000 // inside a filesystem transaction
+	PF_KSWAPD         = 0x00040000 // I am kswapd
+	PF_MEMALLOC_NOIO  = 0x00080000 // Allocating memory without IO involved
+	PF_LESS_THROTTLE  = 0x00100000 // Throttle me less: I clean memory
+	PF_KTHREAD        = 0x00200000 // I am a kernel thread
+	PF_RANDOMIZE      = 0x00400000 // randomize virtual address space
+	PF_SWAPWRITE      = 0x00800000 // Allowed to write to swap
+	PF_NO_SETAFFINITY = 0x04000000 // Userland is not allowed to meddle with cpus_allowed
+	PF_MCE_EARLY      = 0x08000000 // Early kill for mce process policy
+	PF_MUTEX_TESTER   = 0x20000000 // Thread belongs to the rt mutex tester
+	PF_FREEZER_SKIP   = 0x40000000 // Freezer should not count it as freezable
+	PF_SUSPEND_TASK   = 0x80000000 // this thread called freeze_processes and should not be frozen
+)
+
 // State describes the state of a process
 //
 // Known values are presented in constants, taken from ${KERNELSRC}/fs/proc/array.c
@@ -56,7 +90,7 @@ type Stat struct {
 	Session             int    // The session ID of the process
 	TtyNr               int    // Controlling terminal of the process
 	Tpgid               int    // ID of the foreground process of the controlling tmerinal of the process
-	Flags               uint   // Kernel flags word of the process
+	Flags               Flags  // Kernel flags word of the process
 	Minflt              uint   // Number of minor faults the process has made which have not required loading a memory page from disk
 	Cminflt             uint   // Number of minor faults that the process's waited-for children have made
 	Majflt              uint   // Number of major faults that the process's waited-for children have made

--- a/proc/pid/statm.go
+++ b/proc/pid/statm.go
@@ -20,6 +20,9 @@ type Statm struct {
 	Dt       uint // Dirty pages
 }
 
+// NewStatm reads /proc/%{pid}/statm into a Statm instance.
+//
+// Returns an error if opening /proc/%{pid}/statm or parsing an individual value fails.
 func NewStatm(pid int) (*Statm, error) {
 	fn := filepath.Join(Dir(pid), "statm")
 
@@ -34,6 +37,9 @@ func NewStatm(pid int) (*Statm, error) {
 	return NewStatmFromReader(f)
 }
 
+// NewStatmFromReader parses a Statm instance from the given reader.
+//
+// Returns an error if parsing an individual value fails.
 func NewStatmFromReader(reader io.Reader) (*Statm, error) {
 	statm := Statm{}
 

--- a/proc/pid/statm.go
+++ b/proc/pid/statm.go
@@ -1,0 +1,61 @@
+package pid
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+)
+
+// Provides information about memory usage, measured in pages.
+type Statm struct {
+	Size     uint // Total program size
+	Resident uint // Resident set size
+	Share    uint // Shared pages (i.e. backed by a file)
+	Text     uint // Text (code) size
+	Lib      uint // Library size
+	Data     uint // Data + stack size
+	Dt       uint // Dirty pages
+}
+
+func NewStatm(pid int) (*Statm, error) {
+	fn := filepath.Join(Dir(pid), "statm")
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to read %s [%s]", fn, err))
+	}
+
+	defer f.Close()
+
+	return NewStatmFromReader(f)
+}
+
+func NewStatmFromReader(reader io.Reader) (*Statm, error) {
+	statm := Statm{}
+
+	// We rely on reflection to step through the individual elements
+	// of Statm and scan them from reader one by one. Fortunately, Fscan is
+	// clever enough to do the right thing for numerical integer values.
+	v := reflect.ValueOf(&statm).Elem()
+
+	// We need the type later on to provide a rich error message in case
+	// scanning an individual value fails.
+	t := reflect.TypeOf(statm)
+
+	// TODO(tvoss): Right now, we iterate over all fields in the struct, failing if any of those fails to be scanned
+	// We might want to consider member annotations in the future to handle
+	// optional values.
+	for i := 0; i < v.NumField(); i++ {
+		// We need a pointer to the field for passing it to Fscan.
+		field := v.Field(i).Addr()
+		if _, err := fmt.Fscan(reader, field.Interface()); err != nil {
+			return nil, errors.New(fmt.Sprintf("Failed to parse field %s [%v]", t.Field(i).Name, err))
+		}
+	}
+
+	return &statm, nil
+}

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -1,0 +1,4 @@
+package proc
+
+// Dir describes the default mount point of the proc fs.
+const Dir = "/proc"

--- a/process_inspector.go
+++ b/process_inspector.go
@@ -23,9 +23,13 @@ type ProcessReport struct {
 	Statm       pid.Statm       // Statistics about a process's memory usage
 }
 
+// ProcessInspector inspects an individual process
 type ProcessInspector struct {
 }
 
+// Inspect inspects an individual process, returning a report on sucess and nil in case of an error.
+//
+// Returns an error in case of assembling required information fails.
 func (self ProcessInspector) Inspect(id int) (*ProcessReport, error) {
 	pr := ProcessReport{}
 

--- a/process_inspector.go
+++ b/process_inspector.go
@@ -1,6 +1,7 @@
 package csi
 
 import (
+	"fmt"
 	"github.com/vosst/csi/proc/pid"
 )
 
@@ -9,4 +10,60 @@ type ProcessReport struct {
 	Cmdline pid.Cmdline // Command line
 	Cwd     pid.Cwd     // Current working directory
 	Env     pid.Environ // Runtime environment
+	Exe     pid.Exe     // Path to executed command
+	IO      pid.IO      // IO statistics
+	Limits  pid.Limits  // Resource limits
+	Maps    pid.Maps    // Mapped memory regions of the process
+}
+
+type ProcessInspector struct {
+}
+
+func (self ProcessInspector) Inspect(id int) (*ProcessReport, error) {
+	pr := ProcessReport{}
+
+	if cl, err := pid.NewCmdline(id); err != nil {
+		return nil, err
+	} else {
+		pr.Cmdline = cl
+	}
+
+	if cwd, err := pid.NewCwd(id); err != nil {
+		return nil, err
+	} else {
+		pr.Cwd = cwd
+	}
+
+	if env, err := pid.NewEnviron(id); err != nil {
+		return nil, err
+	} else {
+		pr.Env = env
+	}
+
+	if exe, err := pid.NewExe(id); err != nil {
+		return nil, err
+	} else {
+		pr.Exe = exe
+	}
+
+	if io, err := pid.NewIO(id); err != nil {
+		return nil, err
+	} else {
+		pr.IO = *io
+	}
+
+	if limits, err := pid.NewLimits(id); err != nil {
+		fmt.Println(err)
+		return nil, err
+	} else {
+		pr.Limits = limits
+	}
+
+	if maps, err := pid.NewMaps(id); err != nil {
+		return nil, err
+	} else {
+		pr.Maps = maps
+	}
+
+	return &pr, nil
 }

--- a/process_inspector.go
+++ b/process_inspector.go
@@ -18,6 +18,7 @@ type ProcessReport struct {
 	OomScore    pid.OomScore    // Badness score of the process for OOM selection
 	OomScoreAdj pid.OomScoreAdj // New style adjustment factor for altering the kernel's badness heuristic
 	Root        pid.Root        // Filesystem root of a process
+	Stat        pid.Stat        // Statistics about a process
 }
 
 type ProcessInspector struct {
@@ -85,6 +86,13 @@ func (self ProcessInspector) Inspect(id int) (*ProcessReport, error) {
 		return nil, err
 	} else {
 		pr.Root = root
+	}
+
+	if stat, err := pid.NewStat(id); err != nil {
+		fmt.Print(err)
+		return nil, err
+	} else {
+		pr.Stat = *stat
 	}
 
 	return &pr, nil

--- a/process_inspector.go
+++ b/process_inspector.go
@@ -14,6 +14,7 @@ type ProcessReport struct {
 	IO      pid.IO      // IO statistics
 	Limits  pid.Limits  // Resource limits
 	Maps    pid.Maps    // Mapped memory regions of the process
+	OomAdj  pid.OomAdj  // OomAdj factor for altering the kernel's badness heuristic
 }
 
 type ProcessInspector struct {
@@ -63,6 +64,12 @@ func (self ProcessInspector) Inspect(id int) (*ProcessReport, error) {
 		return nil, err
 	} else {
 		pr.Maps = maps
+	}
+
+	if oomAdj, err := pid.NewOomAdj(id); err != nil {
+		return nil, err
+	} else {
+		pr.OomAdj = oomAdj
 	}
 
 	return &pr, nil

--- a/process_inspector.go
+++ b/process_inspector.go
@@ -11,6 +11,7 @@ type ProcessReport struct {
 	Cwd         pid.Cwd         // Current working directory
 	Env         pid.Environ     // Runtime environment
 	Exe         pid.Exe         // Path to executed command
+	Fd          pid.Fd          // All open fds
 	IO          pid.IO          // IO statistics
 	Limits      pid.Limits      // Resource limits
 	Maps        pid.Maps        // Mapped memory regions of the process
@@ -50,6 +51,12 @@ func (self ProcessInspector) Inspect(id int) (*ProcessReport, error) {
 		return nil, err
 	} else {
 		pr.Exe = exe
+	}
+
+	if fd, err := pid.NewFd(id); err != nil {
+		return nil, err
+	} else {
+		pr.Fd = fd
 	}
 
 	if io, err := pid.NewIO(id); err != nil {

--- a/process_inspector.go
+++ b/process_inspector.go
@@ -17,6 +17,7 @@ type ProcessReport struct {
 	OomAdj      pid.OomAdj      // OomAdj factor for altering the kernel's badness heuristic
 	OomScore    pid.OomScore    // Badness score of the process for OOM selection
 	OomScoreAdj pid.OomScoreAdj // New style adjustment factor for altering the kernel's badness heuristic
+	Root        pid.Root        // Filesystem root of a process
 }
 
 type ProcessInspector struct {
@@ -78,6 +79,12 @@ func (self ProcessInspector) Inspect(id int) (*ProcessReport, error) {
 		return nil, err
 	} else {
 		pr.OomScore = oomScore
+	}
+
+	if root, err := pid.NewRoot(id); err != nil {
+		return nil, err
+	} else {
+		pr.Root = root
 	}
 
 	return &pr, nil

--- a/process_inspector.go
+++ b/process_inspector.go
@@ -7,14 +7,15 @@ import (
 
 // ProcessReport bundles information about an individual process.
 type ProcessReport struct {
-	Cmdline pid.Cmdline // Command line
-	Cwd     pid.Cwd     // Current working directory
-	Env     pid.Environ // Runtime environment
-	Exe     pid.Exe     // Path to executed command
-	IO      pid.IO      // IO statistics
-	Limits  pid.Limits  // Resource limits
-	Maps    pid.Maps    // Mapped memory regions of the process
-	OomAdj  pid.OomAdj  // OomAdj factor for altering the kernel's badness heuristic
+	Cmdline  pid.Cmdline  // Command line
+	Cwd      pid.Cwd      // Current working directory
+	Env      pid.Environ  // Runtime environment
+	Exe      pid.Exe      // Path to executed command
+	IO       pid.IO       // IO statistics
+	Limits   pid.Limits   // Resource limits
+	Maps     pid.Maps     // Mapped memory regions of the process
+	OomAdj   pid.OomAdj   // OomAdj factor for altering the kernel's badness heuristic
+	OomScore pid.OomScore // Badness score of the process for OOM selection
 }
 
 type ProcessInspector struct {
@@ -70,6 +71,12 @@ func (self ProcessInspector) Inspect(id int) (*ProcessReport, error) {
 		return nil, err
 	} else {
 		pr.OomAdj = oomAdj
+	}
+
+	if oomScore, err := pid.NewOomScore(id); err != nil {
+		return nil, err
+	} else {
+		pr.OomScore = oomScore
 	}
 
 	return &pr, nil

--- a/process_inspector.go
+++ b/process_inspector.go
@@ -1,0 +1,12 @@
+package csi
+
+import (
+	"github.com/vosst/csi/proc/pid"
+)
+
+// ProcessReport bundles information about an individual process.
+type ProcessReport struct {
+	Cmdline pid.Cmdline // Command line
+	Cwd     pid.Cwd     // Current working directory
+	Env     pid.Environ // Runtime environment
+}

--- a/process_inspector.go
+++ b/process_inspector.go
@@ -19,6 +19,7 @@ type ProcessReport struct {
 	OomScoreAdj pid.OomScoreAdj // New style adjustment factor for altering the kernel's badness heuristic
 	Root        pid.Root        // Filesystem root of a process
 	Stat        pid.Stat        // Statistics about a process
+	Statm       pid.Statm       // Statistics about a process's memory usage
 }
 
 type ProcessInspector struct {
@@ -89,11 +90,15 @@ func (self ProcessInspector) Inspect(id int) (*ProcessReport, error) {
 	}
 
 	if stat, err := pid.NewStat(id); err != nil {
-		fmt.Print(err)
 		return nil, err
 	} else {
 		pr.Stat = *stat
 	}
 
+	if statm, err := pid.NewStatm(id); err != nil {
+		return nil, err
+	} else {
+		pr.Statm = *statm
+	}
 	return &pr, nil
 }

--- a/process_inspector.go
+++ b/process_inspector.go
@@ -7,15 +7,16 @@ import (
 
 // ProcessReport bundles information about an individual process.
 type ProcessReport struct {
-	Cmdline  pid.Cmdline  // Command line
-	Cwd      pid.Cwd      // Current working directory
-	Env      pid.Environ  // Runtime environment
-	Exe      pid.Exe      // Path to executed command
-	IO       pid.IO       // IO statistics
-	Limits   pid.Limits   // Resource limits
-	Maps     pid.Maps     // Mapped memory regions of the process
-	OomAdj   pid.OomAdj   // OomAdj factor for altering the kernel's badness heuristic
-	OomScore pid.OomScore // Badness score of the process for OOM selection
+	Cmdline     pid.Cmdline     // Command line
+	Cwd         pid.Cwd         // Current working directory
+	Env         pid.Environ     // Runtime environment
+	Exe         pid.Exe         // Path to executed command
+	IO          pid.IO          // IO statistics
+	Limits      pid.Limits      // Resource limits
+	Maps        pid.Maps        // Mapped memory regions of the process
+	OomAdj      pid.OomAdj      // OomAdj factor for altering the kernel's badness heuristic
+	OomScore    pid.OomScore    // Badness score of the process for OOM selection
+	OomScoreAdj pid.OomScoreAdj // New style adjustment factor for altering the kernel's badness heuristic
 }
 
 type ProcessInspector struct {


### PR DESCRIPTION
This pull requests adds both the process inspector for gaining insight into an individual process as well as infrastructure for processing data in a procfs. 

For that reason, the PR is quite sizeable, my apologies for that :) Over time, we should think about factoring out the procfs handling into its own project. It is nicely abstracted right now, and easily testable as all types take a reader for construction, enabling us to inject arbitrary good (or bad:)) data and making sure that parsing is as robust as possible.
