### PR TITLE
Add syslog and dmesg

### DIFF
--- a/dmesg/entry.go
+++ b/dmesg/entry.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 )
 
-func facLev(v int) (Facility, Loglevel) {
+func facLev(v uint) (Facility, Loglevel) {
 	return MaskFacility(v), MaskLoglevel(v)
 }
 
@@ -54,7 +54,7 @@ func NewEntry(reader bufio.Reader) (*Entry, error) {
 	entry := Entry{}
 	if matches := dmesgLineRegExp.FindStringSubmatch(line); len(matches) >= 4 {
 		if fl, err := strconv.Atoi(matches[dmesgSmFacLev]); err == nil {
-			entry.Facility, entry.Level = facLev(fl)
+			entry.Facility, entry.Level = facLev(uint(fl))
 		}
 
 		if s, err := strconv.Atoi(matches[dmesgSmTsSec]); err == nil {

--- a/dmesg/entry.go
+++ b/dmesg/entry.go
@@ -1,0 +1,86 @@
+package dmesg
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"syscall"
+)
+
+func facLev(v int) (Facility, Loglevel) {
+	return MaskFacility(v), MaskLoglevel(v)
+}
+
+// dmesgLineRegExp parses an individual line from the kernel log buffer.
+var dmesgLineRegExp = regexp.MustCompile(`<(\d+)>\[(\d+)\.(\d+)\](.*)`)
+
+const (
+	// Submatch index of the facility/level
+	dmesgSmFacLev = 1
+	// Submatch index of the timestamp, seconds part
+	dmesgSmTsSec = 2
+	// Submatch index of the timestamp, microseconds part
+	dmesgSmTsUsec = 3
+	// Submatch index of the actual message
+	dmesgSmMsg = 4
+	// Read all messages remaining in the ring buffer, placing then in the buffer pointed to  by  bufp. The
+	// call reads the last len bytes from the log buffer (nondestructively), but will not read more than was
+	// written into the buffer since the last "clear ring buffer" command (see command 5 below)). The call
+	// returns the number of bytes read.
+	sysActionReadAll int = 3
+	// This command returns the total size of the kernel log buffer.
+	sysActionSizeBuffer int = 10
+)
+
+// Entry models an individual log entry in the kernel ring buffer
+type Entry struct {
+	Level    Loglevel        // Loglevel of the entry
+	Facility Facility        // Facility that the entry originated
+	When     syscall.Timeval // Timestamp of the entry
+	Message  string          // The actual log message
+}
+
+// ReadAll gathers all entries in the kernel log buffer nondestructively.
+//
+// Returns an error if a query to the underlying system facilities fails.
+func ReadAll() ([]Entry, error) {
+	n, err := syscall.Klogctl(10, nil)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to query size of log buffer [%s]", err))
+	}
+
+	b := make([]byte, n, n)
+
+	m, err := syscall.Klogctl(3, b)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to read messages from log buffer [%s]", err))
+	}
+
+	entries := []Entry{}
+	br := bufio.NewReader(bytes.NewReader(b[:m]))
+
+	for line, err := br.ReadString('\n'); err == nil; line, err = br.ReadString('\n') {
+		entry := Entry{}
+		if matches := dmesgLineRegExp.FindStringSubmatch(line); len(matches) >= 4 {
+			if fl, err := strconv.Atoi(matches[dmesgSmFacLev]); err == nil {
+				entry.Facility, entry.Level = facLev(fl)
+			}
+
+			if s, err := strconv.Atoi(matches[dmesgSmTsSec]); err == nil {
+				entry.When.Sec = int64(s)
+			}
+
+			if us, err := strconv.Atoi(matches[dmesgSmTsUsec]); err == nil {
+				entry.When.Usec = int64(us)
+			}
+
+			entry.Message = matches[dmesgSmMsg]
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries, nil
+}

--- a/dmesg/entry.go
+++ b/dmesg/entry.go
@@ -75,14 +75,14 @@ func NewEntry(reader bufio.Reader) (*Entry, error) {
 //
 // Returns an error if a query to the underlying system facilities fails.
 func ReadAll() ([]byte, error) {
-	n, err := syscall.Klogctl(10, nil)
+	n, err := syscall.Klogctl(sysActionSizeBuffer, nil)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Failed to query size of log buffer [%s]", err))
 	}
 
 	b := make([]byte, n, n)
 
-	m, err := syscall.Klogctl(3, b)
+	m, err := syscall.Klogctl(sysActionReadAll, b)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Failed to read messages from log buffer [%s]", err))
 	}

--- a/dmesg/facility.go
+++ b/dmesg/facility.go
@@ -4,7 +4,7 @@ package dmesg
 import "C"
 
 // Facility models well-known log facilities (see man klogctl)
-type Facility int
+type Facility uint
 
 const (
 	LOG_KERN     = C.LOG_KERN     // kernel messages
@@ -22,6 +22,6 @@ const (
 )
 
 // MaskFacility extracts the facility (bottom 3 bits) from the integer value v.
-func MaskFacility(v int) Facility {
+func MaskFacility(v uint) Facility {
 	return Facility((v & 0x03fb) >> 3)
 }

--- a/dmesg/facility.go
+++ b/dmesg/facility.go
@@ -1,0 +1,27 @@
+package dmesg
+
+// #include <sys/syslog.h>
+import "C"
+
+// Facility models well-known log facilities (see man klogctl)
+type Facility int
+
+const (
+	LOG_KERN     = C.LOG_KERN     // kernel messages
+	LOG_USER     = C.LOG_USER     // random user-level messages
+	LOG_MAIL     = C.LOG_MAIL     // mail system
+	LOG_DAEMON   = C.LOG_DAEMON   // system daemons
+	LOG_AUTH     = C.LOG_AUTH     // security/authorization messages
+	LOG_SYSLOG   = C.LOG_SYSLOG   // messages generated internally by syslogd
+	LOG_LPR      = C.LOG_LPR      // line printer subsystem
+	LOG_NEWS     = C.LOG_NEWS     // network news subsystem
+	LOG_UUCP     = C.LOG_UUCP     // UUCP subsystem
+	LOG_CRON     = C.LOG_CRON     // clock daemon
+	LOG_AUTHPRIV = C.LOG_AUTHPRIV // security/authorization messages (private)
+	LOG_FTP      = C.LOG_FTP      // ftp daemon
+)
+
+// MaskFacility extracts the facility (bottom 3 bits) from the integer value v.
+func MaskFacility(v int) Facility {
+	return Facility((v & 0x03fb) >> 3)
+}

--- a/dmesg/facility_test.go
+++ b/dmesg/facility_test.go
@@ -1,0 +1,13 @@
+package dmesg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskFacilityExtractsCorrectBits(t *testing.T) {
+	v := uint(LOG_USER) << 3
+	v |= uint(LOG_ERR)
+	assert.EqualValues(t, LOG_USER, MaskFacility(v))
+}

--- a/dmesg/loglevel.go
+++ b/dmesg/loglevel.go
@@ -4,7 +4,7 @@ package dmesg
 import "C"
 
 // Loglevel models the kernel's loglevel (see man klogctl)
-type Loglevel int
+type Loglevel uint
 
 const (
 	LOG_EMERG   Loglevel = C.LOG_EMERG   // system is unusable
@@ -18,6 +18,6 @@ const (
 )
 
 // MaskLoglevel extracts the Loglevel from the integer value v
-func MaskLoglevel(v int) Loglevel {
+func MaskLoglevel(v uint) Loglevel {
 	return Loglevel(v & 0x07)
 }

--- a/dmesg/loglevel.go
+++ b/dmesg/loglevel.go
@@ -1,0 +1,23 @@
+package dmesg
+
+// #include <sys/syslog.h>
+import "C"
+
+// Loglevel models the kernel's loglevel (see man klogctl)
+type Loglevel int
+
+const (
+	LOG_EMERG   Loglevel = C.LOG_EMERG   // system is unusable
+	LOG_ALERT            = C.LOG_ALERT   // action must be taken immediately
+	LOG_CRIT             = C.LOG_CRIT    // critical conditions
+	LOG_ERR              = C.LOG_ERR     // error conditions
+	LOG_WARNING          = C.LOG_WARNING // warning conditions
+	LOG_NOTICE           = C.LOG_NOTICE  // normal but significant condition
+	LOG_INFO             = C.LOG_INFO    // informational
+	LOG_DEBUG            = C.LOG_DEBUG   // debug-level-messages
+)
+
+// MaskLoglevel extracts the Loglevel from the integer value v
+func MaskLoglevel(v int) Loglevel {
+	return Loglevel(v & 0x07)
+}

--- a/dmesg/loglevel_test.go
+++ b/dmesg/loglevel_test.go
@@ -1,0 +1,13 @@
+package dmesg
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMaskLoglevelExtractsCorrectBits(t *testing.T) {
+	v := uint(LOG_USER) << 3
+	v |= uint(LOG_ERR)
+
+	assert.EqualValues(t, LOG_ERR, MaskLoglevel(v))
+}

--- a/log/collector.go
+++ b/log/collector.go
@@ -20,6 +20,7 @@ type Collector interface {
 type DmesgCollector struct {
 }
 
+// NewDmesgCollector returns a new DmesgCollector.
 func NewDmesgCollector() DmesgCollector {
 	return DmesgCollector{}
 }
@@ -41,6 +42,7 @@ type SyslogCollector struct {
 	fn string // File containing the syslog
 }
 
+// NewSyslogCollector returns a new SyslogCollector gathering information from /var/log/syslog.
 func NewSyslogCollector() SyslogCollector {
 	return SyslogCollector{"/var/log/syslog"}
 }

--- a/log/collector.go
+++ b/log/collector.go
@@ -1,0 +1,55 @@
+package log
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/vosst/csi/dmesg"
+)
+
+// A Collector handles gathering of all contents of a log facility.
+type Collector interface {
+	// Collect gathers a blob of bytes representing the contents of a specific log facility.
+	//
+	// Returns an error if snapshotting the underlying log facility fails.
+	Collect() ([]byte, error)
+}
+
+// A DmesgCollector gathers the contents of the kernel log buffer.
+type DmesgCollector struct {
+}
+
+func NewDmesgCollector() DmesgCollector {
+	return DmesgCollector{}
+}
+
+// Collect returns the contents of the kernel log buffer.
+//
+// Returns an error if querying the kernel log buffer fails due to a lag of permissions.
+func (d DmesgCollector) Collect() ([]byte, error) {
+	blob, err := dmesg.ReadAll()
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to collect contents of the kernel log buffer [%s]", err))
+	}
+
+	return blob, nil
+}
+
+// A SyslogCollector gathers the contents of the syslog.
+type SyslogCollector struct {
+	fn string // File containing the syslog
+}
+
+func NewSyslogCollector() SyslogCollector {
+	return SyslogCollector{"/var/log/syslog"}
+}
+
+func (s SyslogCollector) Collect() ([]byte, error) {
+	blob, err := ioutil.ReadFile(s.fn)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Failed to collect syslog from %s [%s]", s.fn, err))
+	}
+
+	return blob, nil
+}

--- a/system_inspector.go
+++ b/system_inspector.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/vosst/csi/dmesg"
 	"github.com/vosst/csi/pkg"
 )
 
@@ -61,9 +62,10 @@ func parseMounts(reader io.Reader) []Mount {
 
 // OSReport summarizes information about the operating system
 type OSReport struct {
-	Name    string   // Name of the OS
-	Release string   // Relase of the OS
-	Memory  struct { // Information about total available/free memory
+	Name    string        // Name of the OS
+	Release string        // Relase of the OS
+	Dmesg   []dmesg.Entry // Kernel ring buffer contents.
+	Memory  struct {      // Information about total available/free memory
 		Total uint64 // Total usable RAM
 		Free  uint64 // Amound of memory currently unused
 	}
@@ -138,6 +140,10 @@ func (self OSInspector) Inspect() (OSReport, error) {
 
 		osi.Mounts = parseMounts(f)
 
+	}
+
+	if dmesg, err := dmesg.ReadAll(); err == nil {
+		osi.Dmesg = dmesg
 	}
 
 	return osi, nil


### PR DESCRIPTION
This pull request adds a nothing of logs to csi.SystemInspector. We start over with gathering:
- the kernel log buffer, leveraging klogctl
- the syslog, typically located in /var/log/syslog
